### PR TITLE
search: configuring google custom search engine

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -114,7 +114,7 @@ github_project_repo = "https://github.com/cuelang/cue"
 # github_subdir = ""
 
 # Google Custom Search Engine ID. Remove or comment out to disable search.
-# gcs_engine_id = "011737558837375720776:fsdu1nryfng"
+gcs_engine_id = "004591905419617723008:8rmik2a7xb3"
 
 # User interface configuration
 [params.ui]

--- a/content/en/search.md
+++ b/content/en/search.md
@@ -1,0 +1,4 @@
+---
+title: Search Results
+layout: search
+---


### PR DESCRIPTION
atm. search didn't work due to missing configuration. this commit
adds the missing engine id and search page.