### PR TITLE
netlify: changing deploy url to primary url

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,4 @@
-
-# baseURL depends on enviorment.
-# baseURL = "https://cuelang.org"
+baseURL = "https://cuelang.org"
 title = "CUE"
 
 enableRobotsTXT = true

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,8 @@
 [build]
 publish = "public"
+command = "cd themes/docsy && git submodule update -f --init && cd ../.. && hugo"
+
+[context.deploy-preview]
 command = "cd themes/docsy && git submodule update -f --init && cd ../.. && hugo -b $DEPLOY_URL"
 
 [context.deploy-preview.environment]


### PR DESCRIPTION
atm. netlify uses $DEPLOY_URL which gets newly generated on each commit
https://www.netlify.com/docs/continuous-deployment/#environment-variables
setting the base_url for production in the config.toml should be sufficient