### PR TITLE
Remove unnecessary char

### DIFF
--- a/content/en/docs/integrations/json.md
+++ b/content/en/docs/integrations/json.md
@@ -128,7 +128,6 @@ configs <_>: json.Validate(Dimensions)
 configs bed:      #"{ "width": 2, "height": 0.1, "depth": 2 }"#
 configs table:    #"{ "width": "34", "height": 23, "depth": 0.2 }"#
 configs painting: #"{ "width": 34, "height": 12, "depht": 0.2 }"#
-}
 {{< /highlight >}}
 
 {{< highlight none >}}


### PR DESCRIPTION
When executing example in [JSON \| CUE](https://cuelang.org/docs/integrations/json/#validate), I got the following error.

```
$ cue vet dim.cue 
expected 'EOF', found '}':
    ./dim.cue:16:1
terminating because of errors
```

The bracket in the end of `dim.cue` would not be needed.