### PR TITLE
doc/usecase: correcting type-checking example

### DIFF
--- a/content/en/docs/usecases/configuration.md
+++ b/content/en/docs/usecases/configuration.md
@@ -39,7 +39,7 @@ In CUE types and values are a unified concept, which gives it very
 expressive, yet intuitive and compact, typing capabilities.
 
 ```
-Specs :: {
+Spec :: {
   kind: string
 
   name: {
@@ -56,7 +56,7 @@ Specs :: {
 // A spec is of type Spec
 spec: Spec
 spec: {
-  kind: string // error, misspelled field
+  knid: "Homo Sapiens" // error, misspelled field
 
   name first: "Jane"
   name last:  "Doe"


### PR DESCRIPTION
the example on type checking had an spelling error in ther types name resulting
in an `reference "Spec" not found` error. also the comment regarding the error
on a misspelled was not showing.