### PR TITLE
content/main: changing layout of logos to center

### DIFF
--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -55,3 +55,7 @@ input[type="search"]::placeholder {
 #community {
     color: $secondary !important;
 }
+
+.showcase img {
+    margin: 0 30px;
+}

--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -93,21 +93,24 @@ Coming soon.
 {{< blocks/section color="white" >}}
 
 <div class="col-lg-12">
-<h2 class="text-left">Featured Integrations</h2>
-&emsp;{{<imglink ref="json" height="70" src="json.svg" >}}&emsp;
-&emsp;{{<imglink ref="yaml" height="50" src="yaml.png" >}}&emsp;
+<h2 class="text-center">Featured Integrations</h2>
+<p class="text-center showcase">
+{{<imglink ref="json" height="70" src="json.svg" >}}
+{{<imglink ref="yaml" height="50" src="yaml.png" >}}
 {{<imglink ref="go" height="160" src="go.png" >}}
 {{<imglink ref="protobuf" height="200" src="protobuf_nano.png" >}}
-&emsp;{{<imglink ref="openapi" height="70" src="openapi-wide.svg" >}}&emsp;
-&emsp;{{<imglink ref="k8s" height="80" src="k8s.svg" >}}&emsp;
+{{<imglink ref="openapi" height="70" src="openapi-wide.svg" >}}
+{{<imglink ref="k8s" height="80" src="k8s.svg" >}}
+</p>
 </div>
 
 <div class="col">
-<h2 class="text-left">Projects using CUE</h2>
+<h2 class="text-center">Projects using CUE</h2>
 <br>
+<p class="text-center showcase">
 <a href="https://istio.io" target="_blank">
 <img alt="k8s" height="90" src="images/istio.png"/>
 </a>
+</p>
 </div>
 {{< /blocks/section >}}
-


### PR DESCRIPTION
this commit changes the layout of the logos for integrations and
projects using cue to center.