### PR TITLE
docs/references: pointing specification link to cuelang.org

### DIFF
--- a/content/en/docs/references/_index.md
+++ b/content/en/docs/references/_index.md
@@ -27,7 +27,7 @@ See https://github.com/cuelang/cue/issues/10
 ## Language Specification
 
 The source of truth of how the CUE language should behave is encoded in the
-[CUE language specification](https://github.com/cuelang/cue/blob/master/doc/ref/spec.md).
+[CUE language specification](https://cuelang.org/docs/references/spec/).
 Notes on the formalism underlying the specification can be found
 [here](https://github.com/cuelang/cue/blob/master/doc/ref/impl.md).
 


### PR DESCRIPTION
this commit points the link to the specification to the cuelang.org

related: #41