### PR TITLE
Add section about AUR package for Arch Linux

### DIFF
--- a/content/en/docs/install/_index.md
+++ b/content/en/docs/install/_index.md
@@ -25,6 +25,13 @@ In addition, CUE can be installed with using brew on MacOS and Linux:
 brew install cuelang/tap/cue
 ```
 
+### Installation on Arch Linux
+
+For Arch Linux the community maintains a Arch User Repository package called [cuelang-bin](https://aur.archlinux.org/packages/cuelang-bin/):
+
+```
+yay -S cuelang-bin
+```
 
 ## Install CUE from source
 


### PR DESCRIPTION
As I have created a community maintained AUR package we can add it to the installation chapter.