### PR TITLE
docs/integrations/openapi: fix code snippet

### DIFF
--- a/content/en/docs/integrations/openapi.md
+++ b/content/en/docs/integrations/openapi.md
@@ -27,7 +27,7 @@ Generating an OpenAPI definition can be as simple as
 {{< highlight go >}}
 import "cuelang.org/go/encoding/openapi"
 
-func genOpenAPI(inst *cue.Instance) (b []byte, error) {
+func genOpenAPI(inst *cue.Instance) ([]byte, error) {
     b, err := openapi.Gen(inst, nil)
     if err != nil {
         return nil, err


### PR DESCRIPTION
Without this compiling the snippet fails with:
```
./gen.go:11:37: syntax error: mixed named and unnamed function parameters
```