### PR TITLE
Doc site updates - rendering fixes, typos, and hugo compatibility

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,9 @@ set -x
 git submodule update -f --init --recursive
 
 cd cloned
-git clone -n https://github.com/cuelang/cue
+if [[ ! -d cue/ ]] ; then
+  git clone -n https://github.com/cuelang/cue
+fi
 cd cue
 git checkout 317163484ec5d79259a4ea6524d3870419510639
 cd ../..

--- a/config.toml
+++ b/config.toml
@@ -54,6 +54,10 @@ hrefTargetBlank = true
 angledQuotes = false
 latexDashes = true
 
+## Since hugo 0.60 the new renderer requires this for raw HTML to be displayed
+[markup.goldmark.renderer]
+unsafe= true
+
 # Image processing configuration.
 [imaging]
 resampleFilter = "CatmullRom"

--- a/config.toml
+++ b/config.toml
@@ -141,7 +141,7 @@ navbar_logo = false
 	name = "Slack"
 	url = "https://join.slack.com/t/cuelang/shared_invite/enQtNzQwODc3NzYzNTA0LTAxNWQwZGU2YWFiOWFiOWQ4MjVjNGQ2ZTNlMmIxODc4MDVjMDg5YmIyOTMyMjQ2MTkzMTU5ZjA1OGE0OGE1NmE"
 	icon = "fab fa-slack"
-        desc = "Chat with other CUE enthusiast"
+        desc = "Chat with other CUE enthusiasts"
 
 # Developer relevant links. These will show up on right side of footer and in the community page if you have one.
 

--- a/layouts/partials/community_links.html
+++ b/layouts/partials/community_links.html
@@ -1,0 +1,29 @@
+{{ $links := .Site.Params.links }}
+
+<section class="row td-box td-box--4 td-box--gradient td-box--height-auto linkbox">
+<div class="col-xs-12 col-sm-6 col-md-6 col-lg-6">
+<h2>Learn and Connect</h2>		
+<p>Using or want to use {{ .Site.Title }}? Find out more here:
+{{ with index $links "user"}}
+{{ template "community-links-list"  . }}
+{{ end }}
+</div>
+<div class="col-xs-12 col-sm-6 col-md-6 col-lg-6">
+<h2>Develop and Contribute</h2>
+<p>If you want to get more involved by contributing to {{ .Site.Title }}, join us here:
+{{ with index $links "developer"}}
+{{ template "community-links-list"  . }}
+{{ end }}
+<p>You can find out how to contribute to these docs in our <a href="https://github.com/cuelang/cue/blob/master/CONTRIBUTING.md">Contribution Guidelines</a>.
+</div>
+</section>
+
+{{ define "community-links-list" }}
+<ul>
+ {{ range . }}
+ <li title="{{ .name }}">
+   <a target="_blank" href="{{ .url }}"><i class="{{ .icon }}"></i> {{ .name }}:</a> {{ .desc }}
+ </li>
+  {{ end }}
+</ul>
+{{ end }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -8,7 +8,7 @@ MathJax.Hub.Config({
   tex2jax: {
     inlineMath: [['$','$'], ['\\(','\\)']],
     displayMath: [['$$','$$'], ['\[','\]']],
-    skipTags: ['script', 'noscript', 'style', 'textarea', 'pre' ],
+    skipTags: ['script', 'noscript', 'style', 'textarea', 'pre', 'code' ],
     ignoreClass: "mermaid",
     TeX: { equationNumbers: { autoNumber: "AMS" },
          extensions: ["AMSmath.js", "AMSsymbols.js"] }

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -7,7 +7,7 @@
 MathJax.Hub.Config({
   tex2jax: {
     inlineMath: [['$','$'], ['\\(','\\)']],
-    displayMath: [['$$','$$'], ['\[','\]']],
+    displayMath: [['$$','$$']],
     skipTags: ['script', 'noscript', 'style', 'textarea', 'pre', 'code' ],
     ignoreClass: "mermaid",
     TeX: { equationNumbers: { autoNumber: "AMS" },


### PR DESCRIPTION
The default docsy config points 'contribution guidelines'
at a page that doesn't exist on our site.

Also 'enthusiasts' should be plural.