### PR TITLE
Fix typo: missing close-quote

### DIFF
--- a/content/en/docs/about/_index.md
+++ b/content/en/docs/about/_index.md
@@ -175,7 +175,7 @@ For instance,
 could be represented as
 ```
 "a": 3
-"b": "c": "foo
+"b": "c": "foo"
 ```
 All the information of the original JSON file is retained in this
 representation.


### PR DESCRIPTION
typo: "foo -> "foo"