### PR TITLE
ci: explicitly define the version of Go used in tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,12 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@722adc63f1aa60a57ec37892e133b1d319cae598
+    - name: Install Go
+      uses: actions/setup-go@9fbc767707c286e568c92927bbf57d76b73e0892
+      with:
+        go-version: '1.14.1'
+    - name: Regenerate
+      run: go generate ./...
     - name: Check module is tidy
       run: go mod tidy
     - name: Verify commit is clean


### PR DESCRIPTION
Run go mod tidy and friends against a known Go version.