### PR TITLE
all: add redirect from /pkg.go.dev to pkg.go.dev/cuelang.org/go@$version

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -10,6 +10,8 @@ set -x
 if [ "$NETLIFY" = "true" ] && [ "$BRANCH" = "tip" ]
 then
 	GOPROXY=direct go get cuelang.org/go@master
+	# Now force it through the proxy so that the /pkg.go.dev redirect works
+	go get cuelang.org/go@$(go list -m -f={{.Version}} cuelang.org/go)
 fi
 
 git submodule update -f --init --recursive

--- a/content/en/gen.go
+++ b/content/en/gen.go
@@ -1,0 +1,3 @@
+package en
+
+//go:generate go run github.com/cuelang/cuelang.org/internal/gentipredirect

--- a/content/en/pkg.go.dev.md
+++ b/content/en/pkg.go.dev.md
@@ -1,0 +1,4 @@
+---
+type: redirect
+redirectURL: https://pkg.go.dev/cuelang.org/go@v0.0.16-0.20200116123404-317163484ec5
+---

--- a/internal/gentipredirect/main.go
+++ b/internal/gentipredirect/main.go
@@ -1,0 +1,51 @@
+// Copyright 2019 CUE Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// gentipredirect regenerates a simple Hugo markdown file that acts as a redirect
+// to the @master module documentation root on pkg.go.dev
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os/exec"
+	"strings"
+
+	// imported for side effect of module being available in cache
+	_ "cuelang.org/go/pkg"
+)
+
+func main() {
+	log.SetFlags(log.Lshortfile)
+
+	var cueVersion bytes.Buffer
+	cmd := exec.Command("go", "list", "-m", "-f={{.Version}}", "cuelang.org/go")
+	cmd.Stdout = &cueVersion
+	if err := cmd.Run(); err != nil {
+		log.Fatalf("failed to run %v; %v", strings.Join(cmd.Args, " "), err)
+	}
+
+	content := fmt.Sprintf(`---
+type: redirect
+redirectURL: https://pkg.go.dev/cuelang.org/go@%v
+---`, strings.TrimSpace(cueVersion.String()))
+
+	const target = "pkg.go.dev.md"
+
+	if err := ioutil.WriteFile(target, []byte(content), 0666); err != nil {
+		log.Fatalf("failed to write to %v; %v", target, err)
+	}
+}

--- a/layouts/redirect/single.html
+++ b/layouts/redirect/single.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <meta charset="utf-8">
+  <title>Redirecting&hellip;</title>
+  <link rel="canonical" href="{{.Params.redirectURL}}">
+  <script>location="{{.Params.redirectURL}}"</script>
+  <meta http-equiv="refresh" content="0; url={{.Params.redirectURL}}">
+  <meta name="robots" content="noindex">
+  <h1>Redirecting&hellip;</h1>
+  <a href="{{.Params.redirectURL}}">Click here if you are not redirected.</a>
+</html>
+


### PR DESCRIPTION
This is more relevant for tip.cuelang.org, because the master docs on
pkg.go.dev are not currently easily accessible. Hence the advice is:

https://github.com/golang/go/issues/36811#issuecomment-579404726

Therefore we code generate a redirect file based on the required version
of cuelang.org/go (which is automatically updated for tip)