### PR TITLE
all: link to the current version of the Kubernetes tutorial not master

### DIFF
--- a/content/en/docs/about/_index.md
+++ b/content/en/docs/about/_index.md
@@ -277,7 +277,7 @@ typeless data files.
 As soon the desire arises to reduce boilerplate, the `cue` tool can
 help to automatically rewrite configurations.
 See the Quick and Dirty section of the
-[Kubernetes tutorial](https://github.com/cuelang/cue/tree/master/doc/tutorial/kubernetes/README.md)
+[Kubernetes tutorial](/docs/tutorials/kubernetes)
 for an example using the `import` and `trim` tool.
 Thousands of lines can be obliterated automatically using this approach.
 

--- a/content/en/docs/integrations/k8s.md
+++ b/content/en/docs/integrations/k8s.md
@@ -14,7 +14,7 @@ have an abstraction layer that could be converted to not only Kubernetes,
 but also other targets like docker compose, but on the other hand have full
 access to the Kubernetes API without needing continuous support.
 The "Manual" section in the
-[Kubernetes Tutorial](https://cue.googlesource.com/cue/+/refs/heads/master/doc/tutorial/kubernetes/README.md)
+[Kubernetes Tutorial](/docs/tutorials/kubernetes)
 describes how this can be accomplished.
 
 CUE is not specific to Kubernetes, though.

--- a/content/en/docs/tutorials/_index.md
+++ b/content/en/docs/tutorials/_index.md
@@ -10,6 +10,6 @@ There are currently two tutorials:
 - [Basics](/docs/tutorials/tour/intro/):
   this tutorial teaches the basics of the CUE language.
 
-- [Kubernetes](https://github.com/cuelang/cue/blob/master/doc/tutorial/kubernetes/README.md):
+- [Kubernetes](/docs/tutorials/kubernetes):
   this tutorial teaches about the CUE tooling in the context of
   Kubernetes configurations.

--- a/content/en/docs/tutorials/kubernetes.md
+++ b/content/en/docs/tutorials/kubernetes.md
@@ -1,0 +1,4 @@
+---
+type: redirect
+redirectURL: https://github.com/cuelang/cue/blob/v0.1.0/doc/tutorial/kubernetes/README.md
+---

--- a/content/en/docs/tutorials/tutorials.go
+++ b/content/en/docs/tutorials/tutorials.go
@@ -1,0 +1,3 @@
+package tutorials
+
+//go:generate go run github.com/cuelang/cuelang.org/internal/genkubtutredirect

--- a/content/en/docs/usecases/configuration.md
+++ b/content/en/docs/usecases/configuration.md
@@ -111,7 +111,7 @@ On the other hand, CUE's order independence allows abstraction layers
 to inject arbitrary raw API in a controlled manner,
 allowing a general escape hatch to support new or uncovered features.
 See the Manual section of the
-[Kubernetes tutorial](https://github.com/cuelang/cue/tree/master/doc/tutorial/kubernetes/README.md)
+[Kubernetes tutorial](/docs/tutorials/kubernetes)
 for an example.
 
 ### Tooling

--- a/content/en/docs/usecases/scripting.md
+++ b/content/en/docs/usecases/scripting.md
@@ -13,7 +13,7 @@ For now, we refer to the documentation included in the CUE tool itself:
 $ cue help cmd
 ```
 or the "Define Commands" section of the
-[Kubernetes Tutorial](https://cue.googlesource.com/cue/+/refs/heads/master/doc/tutorial/kubernetes/README.md).
+[Kubernetes Tutorial](/docs/tutorials/kubernetes).
 
 {{< alert color="warning" title="note" >}}
 User-defined command line flags are not yet supported.

--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.14
 require (
 	cuelang.org/go v0.1.0
 	github.com/rogpeppe/testscript v1.1.0
+	golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee
 )

--- a/go.sum
+++ b/go.sum
@@ -104,6 +104,7 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
+golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee h1:WG0RUwxtNT4qqaXX3DPA8zHFNm/D9xaBpxzHt1WcA/E=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/internal/genkubtutredirect/main.go
+++ b/internal/genkubtutredirect/main.go
@@ -1,0 +1,59 @@
+// Copyright 2019 CUE Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// gentipredirect regenerates a simple Hugo markdown file that acts as a redirect
+// to the @master module documentation root on pkg.go.dev
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os/exec"
+	"strings"
+
+	// imported for side effect of module being available in cache
+	_ "cuelang.org/go/pkg"
+	"golang.org/x/mod/semver"
+)
+
+func main() {
+	log.SetFlags(log.Lshortfile)
+
+	var cueVersion bytes.Buffer
+	cmd := exec.Command("go", "list", "-m", "-f={{.Version}}", "cuelang.org/go")
+	cmd.Stdout = &cueVersion
+	if err := cmd.Run(); err != nil {
+		log.Fatalf("failed to run %v; %v", strings.Join(cmd.Args, " "), err)
+	}
+	v := strings.TrimSpace(cueVersion.String())
+	if pr := semver.Prerelease(v); pr != "" {
+		// Assume it's a pseudoversion for now, i.e.
+		// v0.1.2-0.20200422131516-4d8d1547ac19 where pr is now
+		// -0.20200422131516-4d8d1547ac19
+		parts := strings.Split(pr, "-")
+		v = parts[2]
+	}
+
+	content := fmt.Sprintf(`---
+type: redirect
+redirectURL: https://github.com/cuelang/cue/blob/%v/doc/tutorial/kubernetes/README.md
+---`, v)
+
+	const target = "kubernetes.md"
+	if err := ioutil.WriteFile(target, []byte(content), 0666); err != nil {
+		log.Fatalf("failed to write to %v; %v", target, err)
+	}
+}


### PR DESCRIPTION
Code generate a simple redirect from /docs/tutorials/kubernetes to the
current version of the tutorial on GitHub. Assume for now that if we
have a pre-release that it's a pseudo-version.