### PR TITLE
Consistent use of filename `check.cue`

### DIFF
--- a/content/en/docs/integrations/yaml.md
+++ b/content/en/docs/integrations/yaml.md
@@ -61,7 +61,7 @@ The `cue vet` command can verify that the values in `ranges.yaml`
 are correct by just mentioning the two files on the command line.
 
 {{< highlight none >}}
-$ cue vet ranges.yaml checks.cue
+$ cue vet ranges.yaml check.cue
 max: invalid value 5 (out of bound >10):
     ./check.cue:2:16
     ./ranges.yaml:5:7


### PR DESCRIPTION
Fix minor consistency issue when referencing the cue file.