### PR TITLE
ci: fix tip build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -18,6 +18,7 @@ then
 	GOPROXY=direct go get cuelang.org/go@master
 	# Now force cuelang.org/go  through the proxy so that the /pkg.go.dev redirect works
 	go get cuelang.org/go@$(go list -m -f={{.Version}} cuelang.org/go)
+	go mod tidy
 
 	# Update the playground
 	cd play

--- a/play/go.mod
+++ b/play/go.mod
@@ -2,4 +2,4 @@ module github.com/cuelang/cuelang.org/play
 
 go 1.14
 
-require github.com/cue-sh/playground v0.0.0-20210107123736-406b3d216f56
+require github.com/cue-sh/playground v0.0.0-20210107141108-1f095289404a

--- a/play/go.sum
+++ b/play/go.sum
@@ -25,8 +25,8 @@ github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
-github.com/cue-sh/playground v0.0.0-20210107123736-406b3d216f56 h1:4xlNQHVqpXgJKLRMJXG3WRlkNxhVkSejwcvqGJXFjk4=
-github.com/cue-sh/playground v0.0.0-20210107123736-406b3d216f56/go.mod h1:5n0T/Y4k6t410O89ZryuC6TcN0D5K5Mvfhn0HA55t4k=
+github.com/cue-sh/playground v0.0.0-20210107141108-1f095289404a h1:K+Kiv4SrlRgPxoLos9JOJWKvqDlvyll3QNGBBAdoXRU=
+github.com/cue-sh/playground v0.0.0-20210107141108-1f095289404a/go.mod h1:5n0T/Y4k6t410O89ZryuC6TcN0D5K5Mvfhn0HA55t4k=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
Was ultimately failing to rebuild a version of the playground which has
itself now become tip-aware, that is when rebuilding the site for tip,
the playground itself upgrade to use the tip of CUE too.