### PR TITLE
protobuf: fix markdown table layout

### DIFF
--- a/content/en/docs/integrations/protobuf.md
+++ b/content/en/docs/integrations/protobuf.md
@@ -29,33 +29,32 @@ Support is planned for
 Proto definitions are mapped to CUE following the Protobuf to JSON mapping.
 Adjusted to CUE:
 
-  Proto type     | CUE type        | Comments
------------------|-----------------|-------------
-  message        | struct          | Message fields become CUE fields, whereby names are mapped to lowerCamelCase.
-  enum           | e1 | e2 | ...   | Where ex are strings. A separate mapping is
-                 |                 | generated to obtain the numeric values.
-  map<K, V>      | { [string]: V } | All keys are converted to strings. 
-  repeated V     | [...V]          | null is accepted as the empty list [].
-  bool           | bool
-  string         | string
-  bytes          | bytes           | A base64-encoded string when converted to JSON.
-  int32, fixed32 | int32           | An integer with bounds as defined by int32.
-  uint32         | uint32          | An integer with bounds as defined by uint32.
-  int64, fixed64 | int64           | An integer with bounds as defined by int64.
-  uint64         | uint64          | An integer with bounds as defined by uint64.
-  float          | float32         | A number with bounds as defined by float32.
-  double         | float64         | A number with bounds as defined by float64.
-  Struct         | struct          | See struct.proto.
-  Value          | _               | See struct.proto.
-  ListValue      | [...]           | See struct.proto.
-  NullValue      | null            | See struct.proto.
-  BoolValue      | bool            | See struct.proto.
-  StringValue    | string          | See struct.proto.
-  NumberValue    | number          | See struct.proto.
-  StringValue    | string          | See struct.proto.
-  Empty          | close({})       |
-  Timestamp      | time.Time       | CUE's builtin Time type.
-  Duration       | time.Duration   | CUE's builtin Duration type.
+| Proto type     | CUE type        | Comments                                                                            |
+| -------------- | --------------- | ----------------------------------------------------------------------------------- |
+| message        | struct          | Message fields become CUE fields, whereby names are mapped to lowerCamelCase.       |
+| enum           | e1 \| e2 \| ... | Where ex are strings. A separate mapping is generated to obtain the numeric values. |
+| map<K, V>      | { [string]: V } | All keys are converted to strings.                                                  |
+| repeated V     | [...V]          | null is accepted as the empty list [].                                              |
+| bool           | bool            |                                                                                     |
+| string         | string          |                                                                                     |
+| bytes          | bytes           | A base64-encoded string when converted to JSON.                                     |
+| int32, fixed32 | int32           | An integer with bounds as defined by int32.                                         |
+| uint32         | uint32          | An integer with bounds as defined by uint32.                                        |
+| int64, fixed64 | int64           | An integer with bounds as defined by int64.                                         |
+| uint64         | uint64          | An integer with bounds as defined by uint64.                                        |
+| float          | float32         | A number with bounds as defined by float32.                                         |
+| double         | float64         | A number with bounds as defined by float64.                                         |
+| Struct         | struct          | See struct.proto.                                                                   |
+| Value          | _               | See struct.proto.                                                                   |
+| ListValue      | [...]           | See struct.proto.                                                                   |
+| NullValue      | null            | See struct.proto.                                                                   |
+| BoolValue      | bool            | See struct.proto.                                                                   |
+| StringValue    | string          | See struct.proto.                                                                   |
+| NumberValue    | number          | See struct.proto.                                                                   |
+| StringValue    | string          | See struct.proto.                                                                   |
+| Empty          | close({})       |                                                                                     |
+| Timestamp      | time.Time       | CUE's builtin Time type.                                                            |
+| Duration       | time.Duration   | CUE's builtin Duration type.                                                        |
 
 
 ### Field Options
@@ -63,11 +62,11 @@ Adjusted to CUE:
 Protobuf definitions can be annotated with CUE constraints that are included
 in the generated CUE:
 
-| Option    | FieldOption | Type    | Comment
-|-----------|--------------|--------|---------
-| (cue.val) |              | string   |    CUE expression defining a constraint for this field. The string may refer to other fields in a message definition using their JSON name.
-| (cue.opt) |
-|            | required |  bool        |   Defines the field is required. Use with caution.
+| Option    | FieldOption | Type   | Comment                                                                                                                                  |
+| --------- | ----------- | ------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| (cue.val) |             | string | CUE expression defining a constraint for this field. The string may refer to other fields in a message definition using their JSON name. |
+| (cue.opt) |             |        |                                                                                                                                          |
+|           | required    | bool   | Defines the field is required. Use with caution.                                                                                         |
 
 An example usage:
 


### PR DESCRIPTION
## Description

Pipes were not properly escaped, resulting in shifted columns in the rendered html.

## Test Guidelines

### Before

<https://cuelang.org/docs/integrations/protobuf/#extract-cue-from-protobuf-definitions>

<img width="1552" alt="image" src="https://user-images.githubusercontent.com/19719047/105610038-6b8c1500-5dad-11eb-93ec-6f406e72d673.png">

### After

Using https://github.com/cuelang/cuelang.org/blob/18fa0fb/README.md#developing-the-site-locally

<img width="1552" alt="image" src="https://user-images.githubusercontent.com/19719047/105610051-8bbbd400-5dad-11eb-8b2e-ca85ca0859cb.png">
