### PR TITLE
usecases/datadef.md: attempt to fix code formatting

### DIFF
--- a/content/en/docs/usecases/datadef.md
+++ b/content/en/docs/usecases/datadef.md
@@ -162,26 +162,28 @@ Compare the following two equivalent schema definitions:
 {{< blocks/section color="white" >}}
 <div class="col">
 CUE
-{{< highlight none >}}
+
+```
 // Definitions.
 
 // Info describes...
 Info: {
-	// Name of the adapter.
-	name: string
+    // Name of the adapter.
+    name: string
 
-	// Templates.
-	templates?: [...string]
+    // Templates.
+    templates?: [...string]
 
-	// Max is the limit.
-	max?: uint & <100
+    // Max is the limit.
+    max?: uint & <100
 }
-{{< /highlight >}}
+```
 </div>
 
 <div class="col">
 OpenAPI
-{{< highlight json >}}
+
+```json
 {
   "openapi": "3.0.0",
   "info": {
@@ -221,7 +223,7 @@ OpenAPI
     }
   }
 }
-{{< /highlight >}}
+```
 </div>
 {{< /blocks/section >}}
 


### PR DESCRIPTION
There's a nested `<pre>` here and I don't understand the generation logic of it. I'm changing these code blocks into markdown-style backtick blocks and converting tabs to spaces to see if that fixes it.

Here's a screenshot of the issue as it appears on an iPhone:
![image](https://user-images.githubusercontent.com/2458645/110733701-6b789500-81f4-11eb-81c0-1f03b4d7480f.png)
