### PR TITLE
general: add a link to the CUE playground in the top menu

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -10,11 +10,14 @@ then
 	exit 1
 fi
 
+env="production"
+
 # If we are running on netlify (i.e. a deploy) and we are building tip then we
 # need to grab the master of our cuelang.org/go and
 # github.com/cue-sh/playground dependencies
 if [ "$BRANCH" = "tip" ]
 then
+	env="tip"
 	GOPROXY=direct go get -d cuelang.org/go@master
 	# Now force cuelang.org/go  through the proxy so that the /pkg.go.dev redirect works
 	go get -d cuelang.org/go@$(go list -m -f={{.Version}} cuelang.org/go)

--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -43,6 +43,10 @@ disableAliases = true
     name = "GitHub"
     weight = 100
     url = "https://github.com/cuelang/cue"
+[[menu.main]]
+    name = "Play"
+    weight = 100
+    url = "https://cuelang.org/play"
 
 # Configure how URLs look like per section.
 [permalinks]

--- a/config/tip/config.toml
+++ b/config/tip/config.toml
@@ -1,0 +1,12 @@
+[[menu.main]]
+    name = "Documentation"
+    weight = -101
+    url = "/docs/"
+[[menu.main]]
+    name = "GitHub"
+    weight = 100
+    url = "https://github.com/cuelang/cue"
+[[menu.main]]
+    name = "Play"
+    weight = 100
+    url = "https://tip.cuelang.org/play"


### PR DESCRIPTION
Alongside the "Documentation", "Community" and "GitHub" links.

In order that this also works for tip.cuelang.org, move to using
configuration directories per:

Per https://gohugo.io/getting-started/configuration/

This allows us then to have a different Play link for tip.cuelang.org.

Fixes #110