### PR TITLE
usecases/datadef.md: Better case for an em-dash

### DIFF
--- a/content/en/docs/usecases/datadef.md
+++ b/content/en/docs/usecases/datadef.md
@@ -15,7 +15,7 @@ values, ranges, and various other constraints.
 OpenAPI even allows for complex logical combinators.
 
 A key difference, however, is that these standards do not unify schema
-and values, the thing that makes CUE so powerful.
+and values—the thing that makes CUE so powerful.
 There is no value lattice.
 This limits these standards in various ways.
 <!-- There is no or very limited possibility for boilerplate removal. -->


### PR DESCRIPTION
I think this is a clearer option than the comma use, which leaves a kind of dangling sentence fragment.

Forgot to make a PR for this after I made the edit a couple of days ago -- last one I had in the hopper. :-)