### PR TITLE
ci: ensure that we are always using the latest CUE

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,11 +12,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2.3.4
+      uses: actions/checkout@v2
     - name: Install Go
-      uses: actions/setup-go@v1.1.3
+      uses: actions/setup-go@v2
       with:
-        go-version: '1.15.6'
+        go-version: '1.16.3'
+    - name: Ensure latest CUE
+      run: go get -d cuelang.org/go@latest # the git clean check later catches this
     - name: Regenerate
       run: go generate ./...
     - name: Check module is tidy

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,7 +5,7 @@
 
 [build.environment]
 HUGO_ENV = "production"
-GO_VERSION = "1.16"
+GO_VERSION = "1.16.3"
 NODE_VERSION = "12.16.1"
 HUGO_VERSION = "0.67.0"
 


### PR DESCRIPTION
Adding the following step to the main CI build for master:

    go get -d cuelang.org/go@latest

in combination with the git clean check, we ensure that cuelang.org is
always referencing the latest CUE, and will fail when it isn't (i.e. we
have just released a new CUE version but not updated cuelang.org). We
could look to automate a PR creation in the future etc, but for now this
is a good fail-safe.