### PR TITLE
ci: check that we are using the latest playground as well as CUE

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,10 @@ jobs:
       # The latest git clean check ensures that this call is effectively
       # side effect-free. Using GOPROXY=direct ensures we don't accidentally
       # hit a stale cache in the proxy.
-      run: GOPROXY=direct go get -d cuelang.org/go@latest
+      run: |
+        GOPROXY=direct go get -d cuelang.org/go@latest
+        cd play
+        GOPROXY=direct go get -d github.com/cue-sh/playground@latest
     - name: Regenerate
       run: go generate ./...
     - name: Check module is tidy

--- a/build.sh
+++ b/build.sh
@@ -13,7 +13,7 @@ fi
 env="production"
 
 # If we are running on netlify (i.e. a deploy) and we are building tip then we
-# need to grab the master of our cuelang.org/go and
+# need to grab the master of our cuelang.org/go and main from
 # github.com/cue-sh/playground dependencies
 if [ "$BRANCH" = "tip" ]
 then
@@ -26,7 +26,7 @@ then
 	# Update the playground. The dist.sh script run below upgrades to the tip of
 	# CUE
 	cd play
-	GOPROXY=direct go get -d github.com/cue-sh/playground@master
+	GOPROXY=direct go get -d github.com/cue-sh/playground@main
 	cd ..
 fi
 


### PR DESCRIPTION
This is basically the position we want to be in. Whilst we don't yet
version the playground, we could. At which point we would ensure that we
are using the latest tagged version. For now, this will effectively
default to the tip of playground, which is fine.

Also flip tip to use @main instead of @master for playground.