### PR TITLE
content: add Code of Conduct

### DIFF
--- a/content/en/docs/contribution_guidelines/_index.md
+++ b/content/en/docs/contribution_guidelines/_index.md
@@ -1,0 +1,36 @@
++++
+title = "Contribution Guidelines"
+weight = 900
++++
+
+CUE is an open source project.
+
+We'd love to accept your patches and contributions to this project. There are
+just a few small guidelines you need to follow.
+
+## Contributor License Agreement
+
+Contributions to this project must be accompanied by a Contributor License
+Agreement. You (or your employer) retain the copyright to your contribution;
+this simply gives us permission to use and redistribute your contributions as
+part of the project. Head over to <https://cla.developers.google.com/> to see
+your current agreements on file or to sign a new one.
+
+You generally only need to submit a CLA once, so if you've already submitted one
+(even if it was for a different project), you probably don't need to do it
+again.
+
+## Code reviews
+
+All submissions, including submissions by project members, require review. We
+use Gerrit code reviews at https://cue-review.googlesource.com for this purpose.
+Please read the [Contributing
+Guide](https://github.com/cuelang/cue/blob/master/doc/contribute.md) before
+reading patches.
+
+## Code of Conduct
+
+Guidelines for participating in CUE community spaces and a reporting process for
+handling issues can be found in the [Code of
+Conduct](/docs/contribution_guidelines/conduct).
+

--- a/content/en/docs/contribution_guidelines/conduct.md
+++ b/content/en/docs/contribution_guidelines/conduct.md
@@ -1,0 +1,196 @@
++++
+title = "Code of Conduct"
+weight = 480
++++
+
+<h2 id="about">About</h2>
+
+<p>
+Online communities include people from many different backgrounds.
+The CUE contributors are committed to providing a friendly, safe and welcoming
+environment for all, regardless of gender identity and expression, sexual orientation,
+disabilities, neurodiversity, physical appearance, body size, ethnicity, nationality,
+race, age, religion, or similar personal characteristics.
+</p>
+
+<p>
+The first goal of the Code of Conduct is to specify a baseline standard
+of behavior so that people with different social values and communication
+styles can talk about CUE effectively, productively, and respectfully.
+</p>
+
+<p>
+The second goal is to provide a mechanism for resolving conflicts in the
+community when they arise.
+</p>
+
+<p>
+The third goal of the Code of Conduct is to make our community welcoming to
+people from different backgrounds.
+Diversity is critical to the project; for CUE to be successful, it needs
+contributors and users from all backgrounds.
+(We take inspiration here from <a href="https://blog.golang.org/open-source">Go, Open Source, Community</a>.)
+</p>
+
+<p>
+We believe that healthy debate and disagreement are essential to a healthy project and community.
+However, it is never ok to be disrespectful.
+We value diverse opinions, but we value respectful behavior more.
+</p>
+
+<h2 id="values">CUE Values</h2>
+
+<p>
+These are the values to which people in the CUE community should aspire.
+</p>
+
+<ul>
+<li>Be friendly and welcoming
+<li>Be patient
+    <ul>
+    <li>Remember that people have varying communication styles and that not
+        everyone is using their native language.
+        (Meaning and tone can be lost in translation.)
+    </ul>
+<li>Be thoughtful
+    <ul>
+    <li>Productive communication requires effort.
+        Think about how your words will be interpreted.
+    <li>Remember that sometimes it is best to refrain entirely from commenting.
+    </ul>
+<li>Be respectful
+    <ul>
+    <li>In particular, respect differences of opinion.
+    </ul>
+<li>Be charitable
+    <ul>
+    <li>Interpret the arguments of others in good faith, do not seek to disagree.
+    <li>When we do disagree, try to understand why.
+    </ul>
+<li>Avoid destructive behavior:
+    <ul>
+    <li>Derailing: stay on topic; if you want to talk about something else,
+        start a new conversation.
+    <li>Unconstructive criticism: don't merely decry the current state of affairs;
+        offer—or at least solicit—suggestions as to how things may be improved.
+    <li>Snarking (pithy, unproductive, sniping comments)
+    <li>Discussing potentially offensive or sensitive issues;
+        this all too often leads to unnecessary conflict.
+    <li>Microaggressions: brief and commonplace verbal, behavioral and
+        environmental indignities that communicate hostile, derogatory or negative
+        slights and insults to a person or group.
+    </ul>
+</ul>
+
+<p>
+People are complicated.
+You should expect to be misunderstood and to misunderstand others;
+when this inevitably occurs, resist the urge to be defensive or assign blame.
+Try not to take offense where no offense was intended.
+Give people the benefit of the doubt.
+Even if the intent was to provoke, do not rise to it.
+It is the responsibility of <i>all parties</i> to de-escalate conflict when it arises.
+</p>
+
+<h2 id="code">Code of Conduct</h2>
+
+<h3 id="our-pledge">Our Pledge</h3>
+
+<p>In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of
+experience, education, socio-economic status, nationality, personal appearance,
+race, religion, or sexual identity and orientation.</p>
+
+<h3 id="our-standards">Our Standards</h3>
+
+<p>Examples of behavior that contributes to creating a positive environment
+include:</p>
+
+<ul>
+<li>Using welcoming and inclusive language</li>
+<li>Being respectful of differing viewpoints and experiences</li>
+<li>Gracefully accepting constructive criticism</li>
+<li>Focusing on what is best for the community</li>
+<li>Showing empathy towards other community members</li>
+</ul>
+
+<p>Examples of unacceptable behavior by participants include:</p>
+
+<ul>
+<li>The use of sexualized language or imagery and unwelcome sexual attention or
+advances</li>
+<li>Trolling, insulting/derogatory comments, and personal or political attacks</li>
+<li>Public or private harassment</li>
+<li>Publishing others&rsquo; private information, such as a physical or electronic
+address, without explicit permission</li>
+<li>Other conduct which could reasonably be considered inappropriate in a
+professional setting</li>
+</ul>
+
+<h3 id="our-responsibilities">Our Responsibilities</h3>
+
+<p>Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.</p>
+
+<p>Project maintainers have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, or to ban temporarily or permanently any
+contributor for other behaviors that they deem inappropriate, threatening,
+offensive, or harmful.</p>
+
+<h3 id="scope">Scope</h3>
+
+<p>This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.</p>
+
+<p>This Code of Conduct also applies outside the project spaces when the Project
+Stewards have a reasonable belief that an individual&rsquo;s behavior may have a
+negative impact on the project or its community.</p>
+
+<h3 id="conflict-resolution"></a>Conflict Resolution</h3>
+
+<p>We do not believe that all conflict is bad; healthy debate and disagreement
+often yield positive results. However, it is never okay to be disrespectful or
+to engage in behavior that violates the project’s code of conduct.</p>
+
+<p>If you see someone violating the code of conduct, you are encouraged to address
+the behavior directly with those involved. Many issues can be resolved quickly
+and easily, and this gives people more control over the outcome of their
+dispute. If you are unable to resolve the matter for any reason, or if the
+behavior is threatening or harassing, report it. We are dedicated to providing
+an environment where participants feel welcome and safe.</p>
+
+<p id="reporting">Reports should be directed to Marcel van Lohuizen and Paul Jolly, the
+CUE Project Stewards, at <i>conduct@cuelang.org</i>.</p>
+
+<p>We will investigate every complaint, but you may not receive a direct response.
+We will use our discretion in determining when and how to follow up on reported
+incidents, which may range from not taking action to permanent expulsion from
+the project and project-sponsored spaces. We will notify the accused of the
+report and provide them an opportunity to discuss it before any action is taken.
+The identity of the reporter will be omitted from the details of the report
+supplied to the accused. In potentially harmful situations, such as ongoing
+harassment or threats to anyone&rsquo;s safety, we may take action without notice.</p>
+
+<h3 id="attribution">Attribution</h3>
+
+<p>This Code of Conduct is adapted from the <a href="https://golang.org/conduct">Go Community Code of Conduct</a>, which
+itself is adapted from the Contributor Covenant, version 1.4, available at <a
+href="https://www.contributor-covenant.org/version/1/4/code-of-conduct.html">https://www.contributor-covenant.org/version/1/4/code-of-conduct.html</a></p>
+
+<h2 id="summary">Summary</h2>
+
+<ul>
+<li>Treat everyone with respect and kindness.
+<li>Be thoughtful in how you communicate.
+<li>Don’t be destructive or inflammatory.
+<li>If you encounter an issue, please mail <a href="mailto:conduct@cuelang.org">conduct@cuelang.org</a>.
+</ul>
+

--- a/layouts/partials/community_links.html
+++ b/layouts/partials/community_links.html
@@ -2,7 +2,7 @@
 
 <section class="row td-box td-box--4 td-box--gradient td-box--height-auto linkbox">
 <div class="col-xs-12 col-sm-6 col-md-6 col-lg-6">
-<h2>Learn and Connect</h2>		
+<h2>Learn and Connect</h2>
 <p>Using or want to use {{ .Site.Title }}? Find out more here:
 {{ with index $links "user"}}
 {{ template "community-links-list"  . }}
@@ -14,7 +14,12 @@
 {{ with index $links "developer"}}
 {{ template "community-links-list"  . }}
 {{ end }}
-<p>You can find out how to contribute to these docs in our <a href="https://github.com/cuelang/cue/blob/master/CONTRIBUTING.md">Contribution Guidelines</a>.
+<p>You can find out how to contribute to the project and these docs in our <a href="/docs/contribution_guidelines">Contribution Guidelines</a>.
+</div>
+<div class="col-xs-12 col-sm-6 col-md-6 col-lg-6">
+<h2>Community Safety</h2>
+<p>Guidelines for participating in CUE community spaces and a reporting process for handling issues can be found in the <a href="/docs/contribution_guidelines/conduct">Code of Conduct</a>.
+follow.
 </div>
 </section>
 


### PR DESCRIPTION
* Add CoC
* Link from Community page directly to the CoC
* Make cuelang.org the home of the contribution guidelines (will link
  back from main CUE repo to these in a subsequent PR in that repo)