### PR TITLE
docs/concepts: copyedit modules document

### DIFF
--- a/content/en/docs/concepts/packages/_index.md
+++ b/content/en/docs/concepts/packages/_index.md
@@ -6,12 +6,12 @@ description = "How files are organized in CUE"
 
 ## Overview
 
-CUE heavily relies on its order independence for package organization.
+CUE relies heavily on its order independence for package organization.
 Definitions and constraints can be split across files within a package,
 and even organized across directories.
 
-Another key aspect of CUE's package management is reproduceability.
-A module, the largest unit of organization, has a fixed location
+Another key aspect of CUE's package management is reproducibility.
+A module—the largest unit of organization—has a fixed location
 of all files and dependencies.
 There are no paths to configure.
 With configuration, reproducibility is key.
@@ -37,20 +37,19 @@ Here is how they differ:
 - All files within a module with the same package name belong to the same package;
   an _instance_ of such a package for a given directory contains all its files
   from that directory up till the module root.
-
 {{% /alert %}}
 
 
 ## Modules
 
-A module contains a configuration layed out in a directory hierarchy.
-It contains the everything that is needed to deterministically
-determine the outcome of a CUE configuration.
+A module contains a configuration laid out in a directory hierarchy.
+It contains everything that is needed to determine the outcome of a
+CUE configuration deterministically.
 The root of this directory is marked by containing a `cue.mod`
 directory.
 The contents of this directory are mostly managed by the `cue` tool.
 In that sense, `cue.mod` is analogous to the `.git` directory marking
-the root directory of a repo, but where its contents are mostly
+the root directory of a repository, but where its contents are mostly
 managed by the `git` tool.
 
 <!--
@@ -77,8 +76,8 @@ within the module root:
 
     cue mod init [module name]
 
-The module name is required if a package within the module needs to
-import another package within the module.
+The module name is required only if a package within the module needs
+to import another package within the same module.
 
 A module can also be created by setting up the `cue.mod` directory
 and `module.cue` file manually.
@@ -91,17 +90,17 @@ The module directory has the following contents:
 ```
 cue.mod
 |-- module.cue  // The module file
-|-- pkg         // copies of external packages
-|-- gen         // files generated from external sources
-|-- usr         // user-defined constraints
+|-- pkg         // Copies of external packages
+|-- gen         // Files generated from external sources
+|-- usr         // User-defined constraints
 ```
 
 Aside from an occasional addition to the `usr` subdirectory or tweak
-to `module.cue`, this directory is
+to the `module.cue` file, this directory is
 predominantly managed by the `cue` tool.
 
 The `module.cue` file defines settings such as
-globally unique _module identifier_ (more on this in the
+the globally unique _module identifier_ (more on this in the
 [Import Path](#ImportPath) section).
 This information allows packages defined within the module to be importable
 within the module itself.
@@ -111,13 +110,13 @@ the precise origin of imported files.
 The other directories hold packages that are facsimiles, derivatives, or
 augmentations of external packages:
 
-- *pkg*: an imported external CUE package,
+- *pkg*: imported CUE packages that are defined externally,
 - *gen*: CUE generated from external definitions, such as protobuf or Go,
 - *usr*: user-defined constraints for the above two directories.
 
 These directories split files from the same package across different
-parallel hierarchies based on the origin of the content.
-But for all intent and purposes they should be seen as a single directory
+parallel hierarchies based on the origin of the content, but for all
+intent and purposes they should be seen as a single directory
 hierarchy.
 
 The `cue.mod/usr` directory is a bit special here.
@@ -125,12 +124,12 @@ The `cue.mod/pkg` and `cue.mod/gen` directories are populated by the `cue` tool.
 The `cue.mod/usr` directory, on the other hand, holds user-defined
 constraints for the packages defined in the other directories.
 
-User-defined constraints can be used to fill gaps in generated constraints;
-as generation is not always a sure thing.
-They can also be used to enforce constraints on imported packages, for instance
-to enforce that a certain API feature is still provided or of the desired form.
-The `usr` directory allows for a cleaner organization compared to storing
-such user-defined constraints directly in the `cue`-managed directories.
+User-defined constraints can be used to fill gaps in generated constraints,
+as generation is not always a sure thing. They can also be used to enforce
+additional constraints on imported packages— for instance to enforce that a
+certain API feature is still provided or of the desired form.  The `usr`
+directory allows for a cleaner organization compared to storing such
+user-defined constraints directly in the `cue`-managed directories.
 
 
 ## Packages
@@ -144,10 +143,11 @@ for instance:
 
     cue eval ./mypkg
 
-it will only look files with such a clause and ignore files without it.
+it will only look at files with such a clause and ignore files without it.
 
-If the package name within the directory is not unique, `cue` needs to
-know the name of the package as well:
+If the package name within the directory is not unique, `cue` needs to know
+the name of the package as well, specified after a separating colon (`:`)
+at the end of the directory path:
 
     cue eval ./mypkg:pkgname
 
@@ -204,7 +204,7 @@ The relative position may not be within the `cue.mod` directory.
 ### Location on disk
 
 A `.cue` file can import a package by specifying its import path
-with the import statement. For instance,
+with an import declaration. For instance,
 
     import (
         "list"
@@ -219,7 +219,7 @@ For other packages, CUE determines the location on disk as follows:
 1. If a module identifier is defined and is a prefix of the import path,
    the package is located at the corresponding location relative to the
    module root.
-2. Otherwise, the package contents looked up in
+2. Otherwise, CUE looks up the package contents in
    the `cue.mod/pkg`, `cue.mod/gen`, and `cue.mod/usr` subdirectores.
 
 In Step 2, an import path may match more than one directory.
@@ -233,8 +233,7 @@ Virtually, these directories should be seen as a single directory tree.
 CUE has a collection of builtin packages that are compiled into the `.cue`
 binary.
 
-A list of these packages form
-can be found here https://godoc.org/cuelang.org/go/pkg.
+Find a list of these packages [here](https://pkg.go.dev/cuelang.org/go/pkg).
 The intention is to have this documentation in CUE format, but for now
 we are piggybacking on the Go infrastructure to host and present the CUE
 packages.
@@ -274,8 +273,8 @@ The top of the hierarchy (the module root) defines constraints that apply
 across the organization.
 Leaf directories typically define concrete instances, inheriting all the
 constraints of ancestor directories.
-Directories between the leaf and top directory define constraints,
-like policies, that only apply to its subdirectories.
+Directories between the leaf and top directory define constraints—like
+policies—that only apply to its subdirectories.
 
 Because order of evaluation does not matter in CUE, leaf packages do not
 explicitly have to specify which parts of their parents they want to inherit

--- a/content/en/docs/concepts/packages/_index.md
+++ b/content/en/docs/concepts/packages/_index.md
@@ -147,9 +147,9 @@ for instance:
 it will only look files with such a clause and ignore files without it.
 
 If the package name within the directory is not unique, `cue` needs to
-know the name of the package as well
+know the name of the package as well:
 
-    cue eval -p pkgname ./mypkg
+    cue eval ./mypkg:pkgname
 
 If no module is defined, it will just load the files in this directory.
 If a module is defined, it will _also_ load all files with the same


### PR DESCRIPTION
Correct the mistaken use of the `-p` (`--package`) flag to specify the package to disambiguate an import location identifier. While we're here, correct a few misspellings and touch up the punctuation in a few places.

This follows from [discussion in the "help" Slack channel](https://cuelang.slack.com/archives/C012UU8B72M/p1619916621111800).