### PR TITLE
all: fix typos, broken link, and references to godoc.org

### DIFF
--- a/content/en/docs/concepts/packages/_index.md
+++ b/content/en/docs/concepts/packages/_index.md
@@ -10,7 +10,7 @@ CUE heavily relies on its order independence for package organization.
 Definitions and constraints can be split across files within a package,
 and even organized across directories.
 
-Another key aspect of CUE's package management is reproduceability.
+Another key aspect of CUE's package management is reproducibility.
 A module, the largest unit of organization, has a fixed location
 of all files and dependencies.
 There are no paths to configure.
@@ -234,7 +234,7 @@ CUE has a collection of builtin packages that are compiled into the `.cue`
 binary.
 
 A list of these packages form
-can be found here https://godoc.org/cuelang.org/go/pkg.
+can be found here https://pkg.go.dev/cuelang.org/go/pkg.
 The intention is to have this documentation in CUE format, but for now
 we are piggybacking on the Go infrastructure to host and present the CUE
 packages.

--- a/content/en/docs/concepts/patterns/_index.md
+++ b/content/en/docs/concepts/patterns/_index.md
@@ -6,6 +6,6 @@ draft = true
 
 Many configuration languages take an inheritance-based approach to reducing
 boilerplate.
-CUE intentionally stears away from this approach and provides
+CUE intentionally steers away from this approach and provides
 an alternative.
 

--- a/content/en/docs/integrations/go.md
+++ b/content/en/docs/integrations/go.md
@@ -12,18 +12,15 @@ available to Go developers and interacts with CUE in various ways.
 
 The CUE APIs in the main repo are organized as follows:
 
-- [**cmd**](https://godoc.org/cuelang.org/go/cmd):
+- [**cmd**](https://pkg.go.dev/cuelang.org/go/cmd):
   The CUE command line tool.
-- [**cue**](https://godoc.org/cuelang.org/go/cue):
+- [**cue**](https://pkg.go.dev/cuelang.org/go/cue):
   core APIs related to parsing, formatting, loading and running CUE programs.
   These packages are used by all other packages, including the command line tool.
-- [**doc**](https://github.com/cuelang/cue/tree/master/doc):
-  [CUE documentation](/docs/references),
-  including tutorials and the reference manual.
-- [**encoding**](https://godoc.org/cuelang.org/go/encoding):
+- [**encoding**](https://pkg.go.dev/cuelang.org/go/encoding):
   Packages for converting to and from CUE, including adaptors for YAML, JSON,
   Go, Protobuf, and OpenAPI.
-- [**pkg**](https://godoc.org/cuelang.org/go/pkg):
+- [**pkg**](https://pkg.go.dev/cuelang.org/go/pkg):
   Builtin packages that are available from within _CUE_ programs.
   These are typically not used in Go code.
 
@@ -83,10 +80,10 @@ or
 There are two primary ways to load CUE into Go.
 To load entire packages, consistent with the `cue` tool,
 use the
-[`cuelang.org/go/cue/load`](https://godoc.org/cuelang.org/go/cue/load)
+[`cuelang.org/go/cue/load`](https://pkg.go.dev/cuelang.org/go/cue/load)
 package.
 To load CUE parse trees or raw CUE text, use a
-[`cuelang.org/go/cue.Runtime`](https://godoc.org/cuelang.org/go/cue#Runtime).
+[`cuelang.org/go/cue.Runtime`](https://pkg.go.dev/cuelang.org/go/cue#Runtime).
 
 {{< alert color="warning" title="Use a single Runtime">}}
 For any operation that involves two CUE values these two values must have
@@ -120,7 +117,7 @@ The names passed to Compile get recorded as references in token positions.
 ### Validate Go values
 
 The `Codec` type in package
-[`cuelang.org/go/encoding/gocode/gocodec`](https://godoc.org/cuelang.org/go/encoding/gocode/gocodec)
+[`cuelang.org/go/encoding/gocode/gocodec`](https://pkg.go.dev/cuelang.org/go/encoding/gocode/gocodec)
  provides the `Validate`
 method for validating Go values.
 
@@ -134,7 +131,7 @@ func (x *MyValue) Validate() error {
 {{< /highlight >}}
 
 Package
-[`cuelang.org/go/encoding/gocode`](https://godoc.org/cuelang.org/go/encoding/gocode),
+[`cuelang.org/go/encoding/gocode`](https://pkg.go.dev/cuelang.org/go/encoding/gocode),
 discussed below,
 can generate these kind of stubs to make life a bit easier.
 
@@ -182,7 +179,7 @@ fmt.Println(x)
 {{< /highlight >}}
 
 Package
-[`cuelang.com/go/encoding/gocode/gocodec`](https://godoc.org/cuelang.org/go/encoding/gocode/gocodec)
+[`cuelang.com/go/encoding/gocode/gocodec`](https://pkg.go.dev/cuelang.org/go/encoding/gocode/gocodec)
  gives a bit more control
 over encoding and allows incorporating Go field tags with constraints as
 well as deriving unspecified values from constraints.
@@ -213,9 +210,9 @@ modifications are only allowed at the whole-instance level.
 
 ### Programmatically
 
-The [`Generate`](https://godoc.org/cuelang.org/go/encoding/gocode#Generate)
+The [`Generate`](https://pkg.go.dev/cuelang.org/go/encoding/gocode#Generate)
 function in package
-[`cuelang.org/go/encoding/gocode`](https://godoc.org/cuelang.org/go/encoding/gocode)
+[`cuelang.org/go/encoding/gocode`](https://pkg.go.dev/cuelang.org/go/encoding/gocode)
 generates stubs for validation functions and method from a given CUE instance.
 It does so by lining up the top-level CUE names with Go definitions.
 The CUE code can use field tags, similar to those used in Go,

--- a/content/en/docs/integrations/json.md
+++ b/content/en/docs/integrations/json.md
@@ -20,7 +20,7 @@ with normal strings, as one cannot tell from the string itself
 if it is to be used as a template or a verbatim string.
 CUE's notation is _not_ valid JSON, meaning it is safe for CUE to give it
 special treatment outside of the JSON spec.
-This way 100% compatability is guaranteed.
+This way 100% compatibility is guaranteed.
 {{< /alert >}}
 
 

--- a/content/en/docs/integrations/openapi.md
+++ b/content/en/docs/integrations/openapi.md
@@ -44,7 +44,7 @@ func genOpenAPI(inst *cue.Instance) ([]byte, error) {
 
 {{< /highlight >}}
 
-The [cuelang.org/go/encoding/openapi](https://godoc.org/cuelang.org/go/encoding/openapi)
+The [cuelang.org/go/encoding/openapi](https://pkg.go.dev/cuelang.org/go/encoding/openapi)
 package provides options to make a definition self-contained,
 expand references, filtering constraints, and so on.
 

--- a/content/en/docs/integrations/protobuf.md
+++ b/content/en/docs/integrations/protobuf.md
@@ -105,7 +105,7 @@ message MyType {
 where the import
 [`cue/cue.proto`](https://cue.googlesource.com/cue/+/refs/heads/master/encoding/protobuf/cue/cue.proto)
 resides in
-[`cuelang.org/go/encoding/protobuf`](https://godoc.org/cuelang.org/go/encoding/protobuf),
+[`cuelang.org/go/encoding/protobuf`](https://pkg.go.dev/cuelang.org/go/encoding/protobuf),
 can be converted to CUE using the following Go code
 
 {{< highlight go >}}
@@ -149,7 +149,7 @@ that map to various different CUE packages within the same module
 importing each other and `.proto` files from other locations.
 This is where things can get hairy.
 
-Package [`cuelang.org/go/encoding/protobuf`](https://godoc.org/cuelang.org/go/encoding/protobuf)
+Package [`cuelang.org/go/encoding/protobuf`](https://pkg.go.dev/cuelang.org/go/encoding/protobuf)
 can be configured to deal with these situations.
 For `.proto` files that have a `go_package` directive, it will use this path.
 If it maps to a package within the CUE module will be generated within the

--- a/content/en/docs/references/_index.md
+++ b/content/en/docs/references/_index.md
@@ -36,17 +36,14 @@ Notes on the formalism underlying the specification can be found
 
 The CUE Go APIs in the main repo are organized as follows:
 
-- [**cmd**](https://godoc.org/cuelang.org/go/cmd):
+- [**cmd**](https://pkg.go.dev/cuelang.org/go/cmd):
   The CUE command line tool.
-- [**cue**](https://godoc.org/cuelang.org/go/cue):
+- [**cue**](https://pkg.go.dev/cuelang.org/go/cue):
   core APIs related to parsing, formatting, loading and running CUE programs.
   These packages are used by all other packages, including the command line tool.
-- [**doc**](https://godoc.org/cuelang.org/go/doc):
-  [CUE documentation](/docs/references),
-  including tutorials and the reference manual.
-- [**encoding**](https://godoc.org/cuelang.org/go/encoding):
+- [**encoding**](https://pkg.go.dev/cuelang.org/go/encoding):
   Packages for converting to and from CUE, including adaptors for YAML, JSON,
   Go, Protobuf, and OpenAPI.
-- [**pkg**](https://godoc.org/cuelang.org/go/pkg):
+- [**pkg**](https://pkg.go.dev/cuelang.org/go/pkg):
   Builtin packages that are available from within _CUE_ programs.
   These are typically not used in Go code.

--- a/content/en/docs/usecases/configuration.md
+++ b/content/en/docs/usecases/configuration.md
@@ -220,7 +220,7 @@ CUE, in turn is influenced by Jsonnet.
 This may give the semblance that the languages are very similar.
 At the core, though, they are very different.
 
-CUE's focus is data validation whereas Jsonnet focusses on data templating
+CUE's focus is data validation whereas Jsonnet focuses on data templating
 (boilerplate removal).
 Jsonnet was not designed with validation in mind.
 

--- a/content/en/docs/usecases/generate.md
+++ b/content/en/docs/usecases/generate.md
@@ -74,7 +74,7 @@ certainly not limited to these cases.
 The [Common Expression Language](https://github.com/google/cel-spec),
 or CEL, defines a simple expression language that can be used as a
 standardization of constraints.
-It focusses on simplicity, speed, termination guarantees and
+It focuses on simplicity, speed, termination guarantees and
 being able run embedded in applications.
 
 Unification of basic typed-feature structures has pseudo-linear run

--- a/content/en/docs/usecases/validation.md
+++ b/content/en/docs/usecases/validation.md
@@ -21,9 +21,9 @@ based on a schema.
 There are not too many handy tools to verify plain data files.
 Often, validation is relied upon to be done server side.
 If it is done client side, it either relies on rather verbose schema
-definitions or using custom tools that verify schema for a specfic domain.
+definitions or using custom tools that verify schema for a specific domain.
 
-The `cue` command line tool provides a fairly straighforward way to
+The `cue` command line tool provides a fairly straightforward way to
 define schema and verify them against a collection of data files.
 
 Given these two files:
@@ -71,7 +71,7 @@ in the definitions, even before they are applied to a concrete case.
 
 CUE can be applied directly on the data in code using its API,
 but it can also be used to compute JSON schemas from CUE definitions.
-(See [cuelang.org/go/encoding/openapi](https://godoc.org/cuelang.org/go/encoding/openapi).)
+(See [cuelang.org/go/encoding/openapi](https://pkg.go.dev/cuelang.org/go/encoding/openapi).)
 If a document-oriented database natively supports JSON schema it will likely
 have its benefits to do so.
 Using CUE to generate the schema has several advantages over doing so directly:


### PR DESCRIPTION
This PR fixes a few typos + a broken link.