### PR TITLE
Complete instruction for cue get go

### DIFF
--- a/content/en/docs/integrations/go.md
+++ b/content/en/docs/integrations/go.md
@@ -34,7 +34,16 @@ The `cue get go` fetches Go packages using Go's package manager
 and makes their definitions available through the CUE module's `pkg` directory
 using the same package naming conventions as in Go.
 
-For example, to download the CUE definitions for the core Kubernetes types, run
+For example, to download the CUE definitions for the core Kubernetes types, 
+initiate a `go.mod` and `cue.mod` if needed in your project directory with
+
+{{< highlight go >}}
+go mod init example.com
+go get k8s.io/api/apps/v1
+cue mod init example.com
+{{< /highlight >}}
+
+and run
 
 {{< highlight go >}}
 cue get go k8s.io/api/core/v1


### PR DESCRIPTION
The command `cue get go ...` has to be issued in a directory with a `go.mod` file and a `cue.mod` directory.
This wasn't explained, and this change introduces the commands creating these.